### PR TITLE
Use "window" instead of "this"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   "dependencies": {
     "jquery": "^1.11.3",
     "fg-overthrow": "0.9.0"
+  },
+  "scripts": {
+    "start": "grunt",
+    "test": "grunt test"
   }
 }

--- a/src/snapper.js
+++ b/src/snapper.js
@@ -255,4 +255,4 @@
 	$( document ).bind( "enhance", function( e ){
 		$( "." + pluginName, e.target ).add( e.target ).filter( "." + pluginName )[ pluginName ]();
 	});
-}( this, jQuery ));
+}( window, jQuery ));


### PR DESCRIPTION
I'm trying to load snapper using webpack and babel-loader, but it seems that babel transpiles `this` to `undefined` (ref https://github.com/webpack/imports-loader/issues/23, http://stackoverflow.com/questions/34973442/how-to-stop-babel-from-transpiling-this-to-undefined)

It seems like `w` always refers to the `window` object, so it should be safe to replace `this` with `window`.

Also added some npm script aliases for the grunt tasks