### PR TITLE
events and fixes for goto/snapping

### DIFF
--- a/src/snapper.js
+++ b/src/snapper.js
@@ -94,15 +94,18 @@
 
 				switch(optionsOrMethod) {
 				case "goto":
-					index = args[0];
-					// width / items * index + (padding) to make sure it goes
-					offset = $slider[ 0 ].scrollLeft + itemWidth * index;
+					index = args[0] % numItems;
+
+					// width / items * index to make sure it goes
+					offset = itemWidth * index;
 					goto( $slider[ 0 ], offset, false, function(){
 						// snap the scroll to the right position
 						snapScroll();
 
 						// invoke the callback if it was supplied
-						if( typeof args[1] === "function" ){ args[1](); }
+						if( typeof args[1] === "function" ){
+							args[1]();
+						}
 					});
 					break;
 				case "getIndex":

--- a/src/snapper.js
+++ b/src/snapper.js
@@ -97,9 +97,12 @@
 					index = args[0];
 					// width / items * index + (padding) to make sure it goes
 					offset = $slider[ 0 ].scrollLeft + itemWidth * index;
-					goto( $slider[ 0 ], offset, function(){
+					goto( $slider[ 0 ], offset, false, function(){
 						// snap the scroll to the right position
 						snapScroll();
+
+						// invoke the callback if it was supplied
+						if( typeof args[1] === "function" ){ args[1](); }
 					});
 					break;
 				case "getIndex":

--- a/src/snapper.js
+++ b/src/snapper.js
@@ -96,7 +96,7 @@
 				case "goto":
 					index = args[0];
 					// width / items * index + (padding) to make sure it goes
-					offset = $slider[ 0 ].scrollLeft + itemWidth * index + (itemWidth * 0.1);
+					offset = $slider[ 0 ].scrollLeft + itemWidth * index;
 					goto( $slider[ 0 ], offset, function(){
 						// snap the scroll to the right position
 						snapScroll();


### PR DESCRIPTION
This triggers an event when the `goto` is actually complete and also fixes an issue where overthrow is used to toss to a new position but the automatic `scroll` binding catches it and stops it with `snapScroll`. 