### PR TITLE
disable momentum css touch scrolling in non-snap browsers

### DIFF
--- a/src/snapper.js
+++ b/src/snapper.js
@@ -383,22 +383,20 @@
 			// apply snapping after scroll, in browsers that don't support CSS scroll-snap
 			var scrollStop;
 			var scrolling;
+			var lastScroll = 0;
+
 			$slider.bind( "scroll", function(e){
-				if( !scrollListening ){
-					//return;
-				}
-				if( scrollStop ){
-					clearTimeout( scrollStop );
-				}
-
+				lastScroll = Date.now();
 				scrolling = true;
+			});
 
-				scrollStop = setTimeout( function(){
+			setInterval(function(){
+				if( scrolling && lastScroll <= Date.now() - 150) {
 					snapScroll();
 					activeItem();
 					scrolling = false;
-				}, 150 );
-			});
+				}
+			}, 150);
 
 			var isTouched = false;
 
@@ -415,6 +413,7 @@
 
 				if(snapScrollCancelled && !scrolling){
 					snapScroll();
+					scrolling = false;
 				}
 			});
 

--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -52,10 +52,12 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	position: relative;
 }
 /* qualify momentum scrolling to native scroll snap support */
-@supports ( -webkit-scroll-snap-type: mandatory ),
-    ( -ms-scroll-snap-type: mandatory ),
+@supports ( -webkit-scroll-snap-type: mandatory ) or
+    ( -ms-scroll-snap-type: mandatory ) or
     ( scroll-snap-type: mandatory ) {
+	.snapper_pane {
     -webkit-overflow-scrolling: touch;
+	}
 }
 .snapper_items {
 	@extend %clearfix;

--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -51,7 +51,7 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	        scroll-snap-points-x: repeat(100%);
 	position: relative;
 }
-/* qualify momentum scrolling to native scroll snap support 
+/* qualify momentum scrolling to native scroll snap support */
 @supports ( -webkit-scroll-snap-type: mandatory ) or
     ( -ms-scroll-snap-type: mandatory ) or
     ( scroll-snap-type: mandatory ) {
@@ -59,7 +59,6 @@ note: only use this if you have thumbnails or some other means of advancing slid
     -webkit-overflow-scrolling: touch;
 	}
 }
-*/
 .snapper_items {
 	@extend %clearfix;
 }

--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -51,7 +51,7 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	        scroll-snap-points-x: repeat(100%);
 	position: relative;
 }
-/* qualify momentum scrolling to native scroll snap support */
+/* qualify momentum scrolling to native scroll snap support 
 @supports ( -webkit-scroll-snap-type: mandatory ) or
     ( -ms-scroll-snap-type: mandatory ) or
     ( scroll-snap-type: mandatory ) {
@@ -59,6 +59,7 @@ note: only use this if you have thumbnails or some other means of advancing slid
     -webkit-overflow-scrolling: touch;
 	}
 }
+*/
 .snapper_items {
 	@extend %clearfix;
 }

--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -41,7 +41,6 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	overflow-y: hidden;
 	white-space: nowrap;
 	width: 100%;
-	-webkit-overflow-scrolling: touch;
 	/* snap to points */
 	-webkit-scroll-snap-type: mandatory;
 	    -ms-scroll-snap-type: mandatory;
@@ -51,6 +50,12 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	    -ms-scroll-snap-points-x: repeat(100%);
 	        scroll-snap-points-x: repeat(100%);
 	position: relative;
+}
+/* qualify momentum scrolling to native scroll snap support */
+@supports ( -webkit-scroll-snap-type: mandatory ),
+    ( -ms-scroll-snap-type: mandatory ),
+    ( scroll-snap-type: mandatory ) {
+    -webkit-overflow-scrolling: touch;
 }
 .snapper_items {
 	@extend %clearfix;


### PR DESCRIPTION
This builds on the perf-hax branch and seems to improve android performance particularly in older devices