### PR TITLE
Whiteout

### DIFF
--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -52,6 +52,19 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	position: relative;
 	z-index: 0;
 }
+.snapper_pane:before,
+.snapper_pane:after {
+	content: "\20";
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	border-left: 1px solid #fff;
+}
+.snapper_pane:after {
+	left: auto;
+	right: 0;
+}
 /* qualify momentum scrolling to native scroll snap support */
 @supports ( -webkit-scroll-snap-type: mandatory ) or
     ( -ms-scroll-snap-type: mandatory ) or

--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -52,16 +52,17 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	position: relative;
 	z-index: 0;
 }
-.snapper_pane:before,
-.snapper_pane:after {
+.snapper:before,
+.snapper:after {
 	content: "\20";
 	position: absolute;
 	top: 0;
 	left: 0;
 	bottom: 0;
 	border-left: 1px solid #fff;
+	display: block;
 }
-.snapper_pane:after {
+.snapper:after {
 	left: auto;
 	right: 0;
 }

--- a/src/snapper.scss
+++ b/src/snapper.scss
@@ -53,7 +53,9 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	z-index: 0;
 }
 .snapper:before,
-.snapper:after {
+.snapper:after,
+.snapper_item:before,
+.snapper_item:after {
 	content: "\20";
 	position: absolute;
 	top: 0;
@@ -62,7 +64,8 @@ note: only use this if you have thumbnails or some other means of advancing slid
 	border-left: 1px solid #fff;
 	display: block;
 }
-.snapper:after {
+.snapper:after,
+.snapper_item:after {
 	left: auto;
 	right: 0;
 }


### PR DESCRIPTION
despite correct reported scroll values, some browsers called Chrome will sometimes reveal a pixel of the next slide. These line dividers mitigate the problem by hiding it. 