### PR TITLE
rm jQuery dependency and add plain JavaScript API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ MIT License
 [c] 2020 Filament Group, Inc
 
 ## Dependencies
-- jQuery or similar DOM library
 - Intersection Observer Polyfill. Run `$ npm install` to download a copy to  `./node_modules/intersection-observer/intersection-observer.js`
 
 ## Demo
 
-<a href="https://fg-snapper.netlify.com/demo/">View the Snapper demos</a>
+<a href="https://fg-snapper.netlify.app/demo/">View the Snapper demos</a>
 
 
 ## Docs
@@ -21,31 +20,49 @@ MIT License
 
 ``` html
 <div class="snapper">
-	<div class="snapper_pane">
-		<div class="snapper_items">
-			<div class="snapper_item" id="img-a">
-				<img src="a-image.jpg" alt="">
-			</div>
-			<div class="snapper_item" id="img-b">
-				<img src="b-image.jpg" alt="">
-			</div>
-			<div class="snapper_item" id="img-c">
-				<img src="c-image.jpg" alt="">
-			</div>
-			<div class="snapper_item" id="img-d">
-				<img src="d-image.jpg" alt="">
-			</div>
-		</div>
-	</div>
+    <div class="snapper_pane">
+        <div class="snapper_items">
+            <div class="snapper_item" id="img-a">
+                <img src="a-image.jpg" alt="">
+            </div>
+            <div class="snapper_item" id="img-b">
+                <img src="b-image.jpg" alt="">
+            </div>
+            <div class="snapper_item" id="img-c">
+                <img src="c-image.jpg" alt="">
+            </div>
+            <div class="snapper_item" id="img-d">
+                <img src="d-image.jpg" alt="">
+            </div>
+        </div>
+    </div>
 </div>
 ```
 
 3. Trigger an "enhance" event on a parent of the markup to initialize. You might do this on domready, as shown below:
 
 ``` js
-$( function(){
-	$( document ).trigger( "enhance" );
+document.addEventListener("DOMContentLoaded", function() {
+    document.dispatchEvent(new Event('enhance'));
 });
+```
+
+or with jQuery:
+
+``` js
+$( function(){
+    $( document ).trigger( "enhance" );
+});
+```
+
+Alternatively, you can enhance a selection of carousel(s) manually:
+``` js
+snapper(document.querySelectorAll('.snapper'));
+```
+
+or with jQuery:
+``` js
+$('.snapper').snapper();
 ```
 
 ### Adding thumbnails
@@ -54,12 +71,13 @@ To add thumbnail or graphic navigation to the carousel, you can append the follo
 
 ``` html
 <div class="snapper_nav">
-	<a href="#img-a"><img src="a-thumb.jpg" alt=""></a>
-	<a href="#img-b"><img src="b-thumb.jpg" alt=""></a>
-	<a href="#img-c"><img src="c-thumb.jpg" alt=""></a>
-	<a href="#img-d"><img src="d-thumb.jpg" alt=""></a>
+    <a href="#img-a"><img src="a-thumb.jpg" alt=""></a>
+    <a href="#img-b"><img src="b-thumb.jpg" alt=""></a>
+    <a href="#img-c"><img src="c-thumb.jpg" alt=""></a>
+    <a href="#img-d"><img src="d-thumb.jpg" alt=""></a>
 </div>
 ```
+
 
 ### Adding next/prev navigation
 
@@ -67,7 +85,7 @@ To add next and previous links that persist state, you can add a `data-snapper-n
 
 ``` html
 <div class="snapper" data-snapper-nextprev>
-	...
+    ...
 </div>
 ```
 
@@ -78,14 +96,15 @@ If you want to show more than one snapper item at a time, you can set the widths
 
 ``` css
 @media (min-width: 30em){
-	.snapper_pane {
-		scroll-snap-points-x: repeat(50%);
-	}
-	.snapper_item {
-		width: 50%;
-	}
+    .snapper_pane {
+        scroll-snap-points-x: repeat(50%);
+    }
+    .snapper_item {
+        width: 50%;
+    }
 }
 ```
+
 
 ### Showing partial image reveals
 
@@ -94,13 +113,14 @@ Just as the above specifies, you can use widths to reveal part of the next image
 
 ``` css
 @media (min-width: 30em){
-	.snapper_pane {
-		scroll-snap-points-x: repeat(45%);
-	}
-	.snapper_item {
-		width: 45%;
-	}
+    .snapper_pane {
+        scroll-snap-points-x: repeat(45%);
+    }
+    .snapper_item {
+        width: 45%;
+    }
 }
+```
 
 
 ### Looping (*experimental)
@@ -110,8 +130,55 @@ To make a snapper loop endlessly in either direction, you can add the data-snapp
 
 ``` html
 <div class="snapper" data-snapper-loop>
-	...
+    ...
 </div>
+```
+
+
+### Methods
+
+The carousel provides the following methods:
+
+| name       | description                       | returns | argument |
+| ---------- | --------------------------------- | ------- | -------- |
+| `goto`     | scroll to item by index           |         | integer  |
+| `getIndex` | get the index of the current item | integer |          |
+
+They can be invoked using plain JavaScript:
+``` js
+snapper(document.querySelector('.snapper'), 'methodName', 'methodArgument');
+```
+
+or using jQuery:
+``` js
+$('.snapper').snapper('methodName', 'methodArgument');
+```
+
+
+### Events
+
+The carousel dispatches the following events:
+
+| name                 | description                                   |
+| -------------------- | --------------------------------------------- |
+| `snapper.after-next` | when navigating to next item                  |
+| `snapper.after-prev` | when navigating to previous item              |
+| `snapper.active`     | fired by carousel item which becomes active   |
+| `snapper.inactive`   | fired by carousel item which becomes inactive |
+
+
+This is how you can listen to them using plain JavaScript:
+``` js
+document.querySelector('.snapper').addEventListener('snapper.xyz', event => {
+    ...
+});
+```
+
+or using jQuery:
+``` js
+$('.snapper').on('snapper.xyz', event => {
+    ...
+});
 ```
 
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,9 +16,10 @@
   }
   </style>
   <script>
-    document.documentElement.className += "enhanced";
-    $(function(){
-      $( document ).trigger( "enhance" );
+    document.documentElement.classList.add("enhanced");
+
+    document.addEventListener("DOMContentLoaded", function() {
+      document.dispatchEvent(new Event('enhance'));
     });
   </script>
 </head>

--- a/dist/snapper-init.js
+++ b/dist/snapper-init.js
@@ -1,7 +1,8 @@
 /* snapper css snap points carousel */
-;(function( w, $ ){
+
+;(function(){
 	// auto-init on enhance
-	$( document ).bind( "enhance", function( e ){
-		$( ".snapper", e.target ).add( e.target ).filter( ".snapper" ).snapper();
+	document.addEventListener( "enhance", function( e ){
+		snapper(e.target.querySelectorAll( ".snapper" ));
 	});
-}( this, jQuery ));
+}());

--- a/dist/snapper.js
+++ b/dist/snapper.js
@@ -1,279 +1,297 @@
 /* snapper css snap points carousel */
-;(function( w, $ ){
+; (function () {
 	var pluginName = "snapper";
-	var navActiveClass = pluginName + "_nav_item-selected";
-	$.fn[ pluginName ] = function(optionsOrMethod){
+	var navActiveClass = `${pluginName}_nav_item-selected`;
+	window[pluginName] = plugin;
+	hasjQuery = window.jQuery !== undefined && window.jQuery.fn !== undefined;
+	if (hasjQuery) {
+		window.jQuery.fn[ pluginName ] = plugin;
+	}
+	
+	function plugin(firstParam, secondParam) {
+		var usesjQuery = !Object.prototype.isPrototypeOf.call(NodeList.prototype, firstParam)
+		var elements = usesjQuery
+			? Array.from(this)
+			: firstParam;
+		var optionsOrMethod = usesjQuery ? firstParam : secondParam;
 		var pluginArgs = arguments;
 
-		function observerCallback( entries ){
-			var parentElem =  $( entries[0].target ).closest( "." + pluginName );
-			var navElem = parentElem.find( "." + pluginName + "_nav" );
-			for(i in entries){
+		function observerCallback(entries) {
+			var parentElem = entries[0].target.closest(`.${pluginName}`);
+			var navElem = parentElem.querySelector(`.${pluginName}_nav`);
+			for (var i in entries) {
 				var entry = entries[i];
-				var entryNavLink = parentElem.find( "a[href='#" + entry.target.id + "']" );
-				if (entry.isIntersecting && entry.intersectionRatio >= .75 ) {
-					entry.target.classList.add( pluginName + "_item-active" );
-					$( entry.target ).trigger( pluginName + ".active" );
-					if( navElem.length ){
-						entryNavLink[0].classList.add( navActiveClass );
-						if( navElem[0].scrollTo ){
-							navElem[0].scrollTo({ left: entryNavLink[0].offsetLeft, behavior: "smooth" });
+				var entryNavLink = parentElem.querySelector(`a[href="#${entry.target.id}"]`);
+				if (entry.isIntersecting && entry.intersectionRatio >= .75) {
+					entry.target.classList.add(`${pluginName}_item-active`);
+					entry.target.dispatchEvent(new CustomEvent(`${pluginName}.active`, { bubbles: true }));
+					if (hasjQuery) {
+						$(entry.target).trigger(`${pluginName}.active`);
+					}
+					if (navElem) {
+						entryNavLink.classList.add(navActiveClass);
+						if (navElem.scrollTo) {
+							navElem.scrollTo({ left: entryNavLink.offsetLeft, behavior: "smooth" });
 						}
 						else {
-							navElem[0].scrollLeft = entryNavLink[0].offsetLeft;
+							navElem.scrollLeft = entryNavLink.offsetLeft;
 						}
 					}
 				}
 				else {
-					entry.target.classList.remove( pluginName + "_item-active" );
-					$( entry.target ).trigger( pluginName + ".inactive" );
-					if( entryNavLink.length ){
-						entryNavLink[0].classList.remove( navActiveClass );
+					entry.target.classList.remove(`${pluginName}_item-active`);
+					entry.target.dispatchEvent(new CustomEvent(`${pluginName}.inactive`, { bubbles: true }));
+					if (hasjQuery) {
+						$(entry.target).trigger(`${pluginName}.inactive`);
+					}
+					if (entryNavLink) {
+						entryNavLink.classList.remove(navActiveClass);
 					}
 				}
 			}
 		}
 
-		function idItems( $elem ){
-			$elem.children().each(function(){
-				if( $( this ).attr("id") === undefined ){
-					$( this ).attr("id", new Date().getTime() );
-				}
-			});
-		}
-
-		function observeItems( elem ){
-			var observer = new IntersectionObserver(observerCallback, {root: elem, threshold: .75 });
-			$( elem ).find( "." + pluginName + "_item" ).each(function(){
-				observer.observe(this);
+		function observeItems(elem) {
+			var observer = new IntersectionObserver(observerCallback, { root: elem, threshold: .75 });
+			elem.querySelectorAll(`.${pluginName}_item`).forEach(function (el) {
+				observer.observe(el);
 			});
 			observer.takeRecords();
 		}
 
 		// get the snapper_item elements whose left offsets fall within the scroll pane.
-		function activeItems( elem ){
-			return $( elem ).find( "." + pluginName + "_item-active" );
+		function activeItems(elem) {
+			return elem.querySelectorAll(`.${pluginName}_item-active`);
 		}
 
 		// sort an item to either end to ensure there's always something to advance to
 		function updateSort(el) {
-			if( !$(el).closest( "[data-snapper-loop], [data-loop]" ).length ){
+			if (!el.closest("[data-snapper-loop], [data-loop]")) {
 				return;
 			}
 			var scrollWidth = el.scrollWidth;
 			var scrollLeft = el.scrollLeft;
-			var contain = $(el).find( "." + pluginName + "_items" );
-			var items = contain.children();
+			var contain = el.querySelector(`.${pluginName}_items`);
+			var items = contain.children;
 			var width = el.offsetWidth;
 
-			if (scrollLeft < width ) {
-			  var sortItem = items.last();
-			  var sortItemWidth = sortItem.width();
-			  contain.prepend(sortItem);
-			  el.scrollLeft = scrollLeft + sortItemWidth;
+			if (scrollLeft < width) {
+				var sortItem = items.length && items[items.length - 1];
+				var sortItemWidth = sortItem.clientWidth;
+				contain.prepend(sortItem);
+				el.scrollLeft = scrollLeft + sortItemWidth;
 			}
-			else if (scrollWidth - scrollLeft - width <= 0 ) {
-			  var sortItem = items.first();
-			  var sortItemWidth = sortItem.width();
-			  contain.append(sortItem);
-			  el.scrollLeft = scrollLeft - sortItemWidth;
+			else if (scrollWidth - scrollLeft - width <= 0) {
+				var sortItem = items.length && items[0];
+				var sortItemWidth = sortItem.clientWidth;
+				contain.append(sortItem);
+				el.scrollLeft = scrollLeft - sortItemWidth;
 			}
 		}
 
 		// disable or enable snapper arrows depending on whether they can advance
-		function setArrowState($el) {
+		function setArrowState(el) {
 			// old api helper here. 
-			if( $el.closest( "[data-snapper-loop], [data-loop]" ).length ){
+			if (el.closest("[data-snapper-loop], [data-loop]")) {
 				return;
 			}
-			var pane = $el.find(".snapper_pane");
-			var nextLink = $el.find(".snapper_nextprev_next");
-			var prevLink = $el.find(".snapper_nextprev_prev");
-			var currScroll = pane[0].scrollLeft;
-			var scrollWidth = pane[0].scrollWidth;
-			var width = pane.width();
+			var pane = el.querySelector(".snapper_pane");
+			var nextLink = el.querySelector(".snapper_nextprev_next");
+			var prevLink = el.querySelector(".snapper_nextprev_prev");
+			var currScroll = pane.scrollLeft;
+			var scrollWidth = pane.scrollWidth;
+			var width = pane.clientWidth;
 
 			var noScrollAvailable = (width === scrollWidth);
 
 			var maxScroll = scrollWidth - width;
-			if (currScroll >= maxScroll - 3 || noScrollAvailable ) { // 3 here is arbitrary tolerance
-				nextLink
-					.addClass("snapper_nextprev-disabled")
-					.attr("tabindex", -1);
-			} else {
-				nextLink
-					.removeClass("snapper_nextprev-disabled")
-					.attr("tabindex", 0);
+			if (nextLink) {
+				if (currScroll >= maxScroll - 3 || noScrollAvailable) { // 3 here is arbitrary tolerance
+					nextLink.classList.add("snapper_nextprev-disabled");
+					nextLink.setAttribute("tabindex", -1);
+				} else {
+					nextLink.classList.remove("snapper_nextprev-disabled");
+					nextLink.setAttribute("tabindex", 0);
+				}
 			}
 
-			if (currScroll > 3 && !noScrollAvailable ) { // 3 is arbitrary tolerance
-				prevLink
-					.removeClass("snapper_nextprev-disabled")
-					.attr("tabindex", 0);
-			} else {
-				prevLink
-					.addClass("snapper_nextprev-disabled")
-					.attr("tabindex", -1);
+			if (prevLink) {
+				if (currScroll > 3 && !noScrollAvailable) { // 3 is arbitrary tolerance
+					prevLink.classList.remove("snapper_nextprev-disabled")
+					prevLink.setAttribute("tabindex", 0);
+				} else {
+					prevLink.classList.add("snapper_nextprev-disabled");
+					prevLink.setAttribute("tabindex", -1);
+				}
 			}
 
-			if( noScrollAvailable ){
-				$el.addClass( "snapper-hide-nav" );
+			if (noScrollAvailable) {
+				el.classList.add("snapper-hide-nav");
 			}
 			else {
-				$el.removeClass( "snapper-hide-nav" );
+				el.classList.remove("snapper-hide-nav");
 			}
 		}
-  
-		function goto( elem, x, callback ){
-			if( elem.scrollTo ){
+
+		function goto(elem, x, callback) {
+			if (elem.scrollTo) {
 				elem.scrollTo({ left: x, behavior: "smooth" });
 			}
 			else {
 				elem.scrollLeft = x;
 			}
-			var activeSlides = activeItems( elem );
+			var activeSlides = activeItems(elem);
 
-			$( elem ).trigger( pluginName + ".after-goto", {
-			 	activeSlides: activeSlides[ 0 ]
-			 });
-			if( callback ){ 
+			elem.closest('.snapper').dispatchEvent(new CustomEvent(`${pluginName}.after-goto`, { bubbles: true }), {
+				activeSlides: activeSlides[0]
+			});
+			if (hasjQuery) {
+				$(elem.closest('.snapper')).trigger(`${pluginName}.after-goto`);
+			}
+			if (callback) {
 				callback();
 			};
 		}
 
-		var result, innerResult;
+		var innerResult;
 
 		// Loop through snapper elements and enhance/bind events
-		result = this.each(function(){
-			if( innerResult !== undefined ){
+		elements.forEach(function (snap) {
+			if (innerResult !== undefined) {
 				return;
 			}
 
-			var self = this;
-			var $self = $( self );
-			var addNextPrev = $self.is( "[data-" + pluginName + "-nextprev]" );
+			var self = snap;
+			var addNextPrev = snap.hasAttribute(`data-${pluginName}-nextprev`);
 			var autoTimeout;
-			var $slider = $( "." + pluginName + "_pane", self );
+			var slider = snap.querySelector(`.${pluginName}_pane`)
 			// give the pane a tabindex for arrow key handling
-			$slider.attr("tabindex", "0");
-			var $itemsContain = $slider.find( "." + pluginName + "_items" );
-			// make sure items are ID'd. This is critical for arrow nav and sorting.
-			idItems( $itemsContain );
-			var $items = $itemsContain.children();
-			$items.addClass( pluginName + "_item" );
-			var numItems = $items.length;						
+			slider.setAttribute("tabindex", "0");
+			var items = slider.querySelector(`.${pluginName}_items`)
 
-			if( typeof optionsOrMethod === "string" ){
-				var args = Array.prototype.slice.call(pluginArgs, 1);
+			for (var item of items.children) {
+				// make sure items are ID'd. This is critical for arrow nav and sorting.
+				if (item.getAttribute("id") === undefined) {
+					item.setAttribute("id", new Date().getTime());
+				}
+				item.classList.add(`${pluginName}_item`)
+			}
+
+			if (typeof optionsOrMethod === "string") {
+				var args = usesjQuery ? pluginArgs : Array.prototype.slice.call(pluginArgs, 1);
 				var index;
 
-				switch(optionsOrMethod) {
-				case "goto":
-					index = args[0] % numItems;
+				switch (optionsOrMethod) {
+					case "goto":
+						index = args[1] % items.children.length;
 
-					var offset = $itemsContain.children().eq(index)[0].offsetLeft;
-					goto( $slider[ 0 ], offset, function(){
-						// invoke the callback if it was supplied
-						if( typeof args[1] === "function" ){
-							args[1]();
-						}
-					});
-					break;
-				case "getIndex":
-					innerResult = activeItems($slider).index();
-					break;
+						var offset = items.children[index].offsetLeft;
+						goto(slider, offset, function () {
+							// invoke the callback if it was supplied
+							if (typeof args[1] === "function") {
+								args[1]();
+							}
+						});
+						break;
+					case "getIndex":
+						var currentItem = activeItems(slider)[0];
+						innerResult = Array.from(currentItem.parentElement.children).findIndex(child => child === currentItem)
+						break;
 				}
 				return;
 			}
 
 			// avoid double enhance activities
-			if( $self.attr("data-" + pluginName + "-enhanced") ) {
+			if (snap.getAttribute(`data-${pluginName}-enhanced`)) {
 				return;
 			}
 
-			observeItems($slider[ 0 ]);
+			observeItems(slider);
 
 			// if the nextprev option is set, add the nextprev nav
-			if( addNextPrev ){
-				var	$nextprev = $( '<ul class="snapper_nextprev"><li class="snapper_nextprev_item"><a href="#prev" class="snapper_nextprev_prev">Prev</a></li><li class="snapper_nextprev_item"><a href="#next" class="snapper_nextprev_next">Next</a></li></ul>' );
-				var $nextprevContain = $( ".snapper_nextprev_contain", self );
-				if( !$nextprevContain.length ){
-					$nextprevContain = $( self );
+			if (addNextPrev) {
+				var nextprev = document.createElement('ul');
+				nextprev.classList.add('snapper_nextprev');
+				nextprev.innerHTML = '<li class="snapper_nextprev_item"><a href="#prev" class="snapper_nextprev_prev">Prev</a></li><li class="snapper_nextprev_item"><a href="#next" class="snapper_nextprev_next">Next</a></li>';
+				var nextprevContain = self.querySelector(".snapper_nextprev_contain");
+				if (!nextprevContain) {
+					nextprevContain = self;
 				}
-				$nextprev.appendTo( $nextprevContain );
+				nextprevContain.appendChild(nextprev);
 			}
 
 			// This click binding will allow linking to slides from thumbnails without causing the page to scroll to the carousel container
 			// this also supports click handling for generated next/prev links
-			$( "a", this ).bind( "click", function( e ){
-				clearTimeout(autoTimeout);
-				var slideID = $( this ).attr( "href" );
+			snap.querySelectorAll("a").forEach(el => {
+				el.addEventListener("click", function (e) {
+					clearTimeout(autoTimeout);
+					var slideID = this.getAttribute("href");
 
-				if( $( this ).is( ".snapper_nextprev_next" ) ){
-					e.preventDefault();
-					return arrowNavigate( true );
-				}
-				else if( $( this ).is( ".snapper_nextprev_prev" ) ){
-					e.preventDefault();
-					return arrowNavigate( false );
-				}
-				// internal links to slides
-				else if( slideID.indexOf( "#" ) === 0 && slideID.length > 1 ){
-					e.preventDefault();
-					gotoSlide( slideID );
-				}
+					if (this.classList.contains("snapper_nextprev_next")) {
+						e.preventDefault();
+						return arrowNavigate(true);
+					}
+					else if (this.classList.contains("snapper_nextprev_prev")) {
+						e.preventDefault();
+						return arrowNavigate(false);
+					}
+					// internal links to slides
+					else if (slideID.indexOf("#") === 0 && slideID.length > 1) {
+						e.preventDefault();
+						gotoSlide(slideID);
+					}
+				});
 			});
 
 			// arrow key bindings for next/prev
-			$( this )
-				.bind( "keydown", function( e ){
-					if( e.keyCode === 37 || e.keyCode === 38 ){
-						clearTimeout(autoTimeout);
-						e.preventDefault();
-						e.stopImmediatePropagation();
-						arrowNavigate( false );
-					}
-					if( e.keyCode === 39 || e.keyCode === 40 ){
-						clearTimeout(autoTimeout);
-						e.preventDefault();
-						e.stopImmediatePropagation();
-						arrowNavigate( true );
-					}
-				} );
+			snap.addEventListener("keydown", function (e) {
+				if (e.keyCode === 37 || e.keyCode === 38) {
+					clearTimeout(autoTimeout);
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					arrowNavigate(false);
+				}
+				if (e.keyCode === 39 || e.keyCode === 40) {
+					clearTimeout(autoTimeout);
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					arrowNavigate(true);
+				}
+			});
 
-			function gotoSlide( href, callback ){
-				var $slide = $( href, self );
-				if( $slide.length ){
-					goto( $slider[ 0 ], $slide[ 0 ].offsetLeft, function(){
-						if( callback ){
+			function gotoSlide(href, callback) {
+				var slide = self.querySelector(href);
+				if (slide) {
+					goto(slider, slide.offsetLeft, function () {
+						if (callback) {
 							callback();
 						}
-					} );
+					});
 				}
 			}
 
 
-			
+
 			var afterResize;
 			var currSlide;
-			function resizeUpdates(){
-				clearTimeout( afterResize );
-				if( !currSlide ){
-					currSlide = activeItems($slider).first();
+			function resizeUpdates() {
+				clearTimeout(afterResize);
+				if (!currSlide) {
+					currSlide = activeItems(slider).length && activeItems(slider)[0];
 				}
-				afterResize = setTimeout( function(){
+				afterResize = setTimeout(function () {
 					// retain snapping on resize 
-					gotoSlide( currSlide.attr("id") );
+					gotoSlide(currSlide.getAttribute("id"));
 					currSlide = null;
 					// resize can reveal or hide slides, so update arrows
-					setArrowState( $self );
-				}, 300 );
+					setArrowState(self);
+				}, 300);
 			}
-			$( w ).bind( "resize", resizeUpdates );
+			window.addEventListener("resize", resizeUpdates);
 
 			// next/prev links or arrows should loop back to the other end when an extreme is reached
-			function arrowNavigate( forward ){
-				if( forward ){
+			function arrowNavigate(forward) {
+				if (forward) {
 					next();
 				}
 				else {
@@ -282,31 +300,38 @@
 			}
 
 			// advance slide one full scrollpane's width forward
-			function next(){
-				var currentActive =  activeItems($slider).first();
-				var next = currentActive.next();
-				if( next.length ){
-					gotoSlide( "#" + next.attr( "id" ), function(){
-						$slider.trigger( pluginName + ".after-next" );
-					} );
+			function next() {
+				var currentActive = activeItems(slider).length && activeItems(slider)[0];
+				var next = currentActive.nextElementSibling;
+				if (next) {
+					gotoSlide(`#${next.getAttribute("id")}`, function () {
+						snap.dispatchEvent(new CustomEvent(`${pluginName}.after-next`, { bubbles: true }));
+						if (hasjQuery) {
+							$(snap).trigger(`${pluginName}.after-next`);
+						}
+					});
 				}
 			}
 
 			// advance slide one full scrollpane's width backwards
-			function prev(){
-				var currentActive =  activeItems($slider).first();
-				var prev = currentActive.prev();
-				if( prev.length ){
-					gotoSlide( "#" + prev.attr( "id" ), function(){
-						$slider.trigger( pluginName + ".after-prev" );
-					} );
+			function prev() {
+				var currentActive = activeItems(slider).length && activeItems(slider)[0];
+				var prev = currentActive.previousElementSibling;
+				if (prev) {
+					gotoSlide(`#${prev.getAttribute("id")}`, function () {
+						snap.dispatchEvent(new CustomEvent(`${pluginName}.after-prev`, { bubbles: true }));
+						if (hasjQuery) {
+							$(snap).trigger(`${pluginName}.after-prev`);
+						}
+					});
 				}
 			}
 
 			function getAutoplayInterval() {
-				var activeSlide = activeItems($slider).last();
-				var autoTiming = activeSlide.attr( "data-snapper-autoplay" ) || $self.attr( "data-snapper-autoplay" );
-				if( autoTiming ) {
+				var currentActive = activeItems(slider)
+				var activeSlide = currentActive.length && currentActive[currentActive.length - 1];
+				var autoTiming = activeSlide && activeSlide.getAttribute("data-snapper-autoplay") || self.getAttribute("data-snapper-autoplay");
+				if (autoTiming) {
 					autoTiming = parseInt(autoTiming, 10) || 5000;
 				}
 				return autoTiming;
@@ -314,14 +339,14 @@
 
 			// if the `data-autoplay` attribute is assigned a natural number value
 			// use it to make the slides cycle until there is a user interaction
-			function autoplay( autoTiming ) {
-				if( autoTiming ){
+			function autoplay(autoTiming) {
+				if (autoTiming) {
 					// autoTimeout is cleared in each user interaction binding
-					autoTimeout = setTimeout(function(){
+					autoTimeout = setTimeout(function () {
 						var timeout = getAutoplayInterval();
-						if( timeout ) {
+						if (timeout) {
 							arrowNavigate(true);
-							autoplay( timeout );
+							autoplay(timeout);
 						}
 					}, autoTiming);
 				}
@@ -329,27 +354,32 @@
 
 			// if a touch event is fired on the snapper we know the user is trying to
 			// interact with it and we should disable the auto play
-			$slider.bind("pointerdown click mouseenter focus", function(){
-				clearTimeout(autoTimeout);
+			["pointerdown", "click", "mouseenter", "focus"].forEach(eventType => {
+				slider.addEventListener(eventType, function () {
+					clearTimeout(autoTimeout);
+				});
 			});
 
 			var scrolling;
-			$slider.bind("scroll", function(){
+			slider.addEventListener("scroll", function () {
 				window.clearTimeout(scrolling);
-				scrolling = setTimeout(function(){
-					updateSort( $slider[0] );
-					setArrowState( $self );
-				},66);
+				scrolling = setTimeout(function () {
+					updateSort(slider);
+					setArrowState(self);
+				}, 66);
 			});
 
-			updateSort( $slider[0] );
-			
-			setArrowState( $self );
+			updateSort(slider);
 
-			autoplay( getAutoplayInterval() );
-			$self.attr("data-" + pluginName + "-enhanced", true);
+			setArrowState(self);
+
+			autoplay(getAutoplayInterval());
+			self.setAttribute(`data-${pluginName}-enhanced`, true);
 		});
 
-		return (innerResult !== undefined ? innerResult : result);
+
+		return innerResult !== undefined
+			? innerResult
+			: (usesjQuery ? this : elements);
 	};
-}( this, jQuery ));
+}());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fg-snapper",
-  "version": "4.0.0-0",
+  "version": "4.0.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/snapper-init.js
+++ b/src/snapper-init.js
@@ -1,7 +1,8 @@
 /* snapper css snap points carousel */
-;(function( w, $ ){
+
+;(function(){
 	// auto-init on enhance
-	$( document ).bind( "enhance", function( e ){
-		$( ".snapper", e.target ).add( e.target ).filter( ".snapper" ).snapper();
+	document.addEventListener( "enhance", function( e ){
+		snapper(e.target.querySelectorAll( ".snapper" ));
 	});
-}( this, jQuery ));
+}());

--- a/src/snapper.js
+++ b/src/snapper.js
@@ -1,279 +1,297 @@
 /* snapper css snap points carousel */
-;(function( w, $ ){
+; (function () {
 	var pluginName = "snapper";
-	var navActiveClass = pluginName + "_nav_item-selected";
-	$.fn[ pluginName ] = function(optionsOrMethod){
+	var navActiveClass = `${pluginName}_nav_item-selected`;
+	window[pluginName] = plugin;
+	hasjQuery = window.jQuery !== undefined && window.jQuery.fn !== undefined;
+	if (hasjQuery) {
+		window.jQuery.fn[ pluginName ] = plugin;
+	}
+	
+	function plugin(firstParam, secondParam) {
+		var usesjQuery = !Object.prototype.isPrototypeOf.call(NodeList.prototype, firstParam)
+		var elements = usesjQuery
+			? Array.from(this)
+			: firstParam;
+		var optionsOrMethod = usesjQuery ? firstParam : secondParam;
 		var pluginArgs = arguments;
 
-		function observerCallback( entries ){
-			var parentElem =  $( entries[0].target ).closest( "." + pluginName );
-			var navElem = parentElem.find( "." + pluginName + "_nav" );
-			for(i in entries){
+		function observerCallback(entries) {
+			var parentElem = entries[0].target.closest(`.${pluginName}`);
+			var navElem = parentElem.querySelector(`.${pluginName}_nav`);
+			for (var i in entries) {
 				var entry = entries[i];
-				var entryNavLink = parentElem.find( "a[href='#" + entry.target.id + "']" );
-				if (entry.isIntersecting && entry.intersectionRatio >= .75 ) {
-					entry.target.classList.add( pluginName + "_item-active" );
-					$( entry.target ).trigger( pluginName + ".active" );
-					if( navElem.length ){
-						entryNavLink[0].classList.add( navActiveClass );
-						if( navElem[0].scrollTo ){
-							navElem[0].scrollTo({ left: entryNavLink[0].offsetLeft, behavior: "smooth" });
+				var entryNavLink = parentElem.querySelector(`a[href="#${entry.target.id}"]`);
+				if (entry.isIntersecting && entry.intersectionRatio >= .75) {
+					entry.target.classList.add(`${pluginName}_item-active`);
+					entry.target.dispatchEvent(new CustomEvent(`${pluginName}.active`, { bubbles: true }));
+					if (hasjQuery) {
+						$(entry.target).trigger(`${pluginName}.active`);
+					}
+					if (navElem) {
+						entryNavLink.classList.add(navActiveClass);
+						if (navElem.scrollTo) {
+							navElem.scrollTo({ left: entryNavLink.offsetLeft, behavior: "smooth" });
 						}
 						else {
-							navElem[0].scrollLeft = entryNavLink[0].offsetLeft;
+							navElem.scrollLeft = entryNavLink.offsetLeft;
 						}
 					}
 				}
 				else {
-					entry.target.classList.remove( pluginName + "_item-active" );
-					$( entry.target ).trigger( pluginName + ".inactive" );
-					if( entryNavLink.length ){
-						entryNavLink[0].classList.remove( navActiveClass );
+					entry.target.classList.remove(`${pluginName}_item-active`);
+					entry.target.dispatchEvent(new CustomEvent(`${pluginName}.inactive`, { bubbles: true }));
+					if (hasjQuery) {
+						$(entry.target).trigger(`${pluginName}.inactive`);
+					}
+					if (entryNavLink) {
+						entryNavLink.classList.remove(navActiveClass);
 					}
 				}
 			}
 		}
 
-		function idItems( $elem ){
-			$elem.children().each(function(){
-				if( $( this ).attr("id") === undefined ){
-					$( this ).attr("id", new Date().getTime() );
-				}
-			});
-		}
-
-		function observeItems( elem ){
-			var observer = new IntersectionObserver(observerCallback, {root: elem, threshold: .75 });
-			$( elem ).find( "." + pluginName + "_item" ).each(function(){
-				observer.observe(this);
+		function observeItems(elem) {
+			var observer = new IntersectionObserver(observerCallback, { root: elem, threshold: .75 });
+			elem.querySelectorAll(`.${pluginName}_item`).forEach(function (el) {
+				observer.observe(el);
 			});
 			observer.takeRecords();
 		}
 
 		// get the snapper_item elements whose left offsets fall within the scroll pane.
-		function activeItems( elem ){
-			return $( elem ).find( "." + pluginName + "_item-active" );
+		function activeItems(elem) {
+			return elem.querySelectorAll(`.${pluginName}_item-active`);
 		}
 
 		// sort an item to either end to ensure there's always something to advance to
 		function updateSort(el) {
-			if( !$(el).closest( "[data-snapper-loop], [data-loop]" ).length ){
+			if (!el.closest("[data-snapper-loop], [data-loop]")) {
 				return;
 			}
 			var scrollWidth = el.scrollWidth;
 			var scrollLeft = el.scrollLeft;
-			var contain = $(el).find( "." + pluginName + "_items" );
-			var items = contain.children();
+			var contain = el.querySelector(`.${pluginName}_items`);
+			var items = contain.children;
 			var width = el.offsetWidth;
 
-			if (scrollLeft < width ) {
-			  var sortItem = items.last();
-			  var sortItemWidth = sortItem.width();
-			  contain.prepend(sortItem);
-			  el.scrollLeft = scrollLeft + sortItemWidth;
+			if (scrollLeft < width) {
+				var sortItem = items.length && items[items.length - 1];
+				var sortItemWidth = sortItem.clientWidth;
+				contain.prepend(sortItem);
+				el.scrollLeft = scrollLeft + sortItemWidth;
 			}
-			else if (scrollWidth - scrollLeft - width <= 0 ) {
-			  var sortItem = items.first();
-			  var sortItemWidth = sortItem.width();
-			  contain.append(sortItem);
-			  el.scrollLeft = scrollLeft - sortItemWidth;
+			else if (scrollWidth - scrollLeft - width <= 0) {
+				var sortItem = items.length && items[0];
+				var sortItemWidth = sortItem.clientWidth;
+				contain.append(sortItem);
+				el.scrollLeft = scrollLeft - sortItemWidth;
 			}
 		}
 
 		// disable or enable snapper arrows depending on whether they can advance
-		function setArrowState($el) {
+		function setArrowState(el) {
 			// old api helper here. 
-			if( $el.closest( "[data-snapper-loop], [data-loop]" ).length ){
+			if (el.closest("[data-snapper-loop], [data-loop]")) {
 				return;
 			}
-			var pane = $el.find(".snapper_pane");
-			var nextLink = $el.find(".snapper_nextprev_next");
-			var prevLink = $el.find(".snapper_nextprev_prev");
-			var currScroll = pane[0].scrollLeft;
-			var scrollWidth = pane[0].scrollWidth;
-			var width = pane.width();
+			var pane = el.querySelector(".snapper_pane");
+			var nextLink = el.querySelector(".snapper_nextprev_next");
+			var prevLink = el.querySelector(".snapper_nextprev_prev");
+			var currScroll = pane.scrollLeft;
+			var scrollWidth = pane.scrollWidth;
+			var width = pane.clientWidth;
 
 			var noScrollAvailable = (width === scrollWidth);
 
 			var maxScroll = scrollWidth - width;
-			if (currScroll >= maxScroll - 3 || noScrollAvailable ) { // 3 here is arbitrary tolerance
-				nextLink
-					.addClass("snapper_nextprev-disabled")
-					.attr("tabindex", -1);
-			} else {
-				nextLink
-					.removeClass("snapper_nextprev-disabled")
-					.attr("tabindex", 0);
+			if (nextLink) {
+				if (currScroll >= maxScroll - 3 || noScrollAvailable) { // 3 here is arbitrary tolerance
+					nextLink.classList.add("snapper_nextprev-disabled");
+					nextLink.setAttribute("tabindex", -1);
+				} else {
+					nextLink.classList.remove("snapper_nextprev-disabled");
+					nextLink.setAttribute("tabindex", 0);
+				}
 			}
 
-			if (currScroll > 3 && !noScrollAvailable ) { // 3 is arbitrary tolerance
-				prevLink
-					.removeClass("snapper_nextprev-disabled")
-					.attr("tabindex", 0);
-			} else {
-				prevLink
-					.addClass("snapper_nextprev-disabled")
-					.attr("tabindex", -1);
+			if (prevLink) {
+				if (currScroll > 3 && !noScrollAvailable) { // 3 is arbitrary tolerance
+					prevLink.classList.remove("snapper_nextprev-disabled")
+					prevLink.setAttribute("tabindex", 0);
+				} else {
+					prevLink.classList.add("snapper_nextprev-disabled");
+					prevLink.setAttribute("tabindex", -1);
+				}
 			}
 
-			if( noScrollAvailable ){
-				$el.addClass( "snapper-hide-nav" );
+			if (noScrollAvailable) {
+				el.classList.add("snapper-hide-nav");
 			}
 			else {
-				$el.removeClass( "snapper-hide-nav" );
+				el.classList.remove("snapper-hide-nav");
 			}
 		}
-  
-		function goto( elem, x, callback ){
-			if( elem.scrollTo ){
+
+		function goto(elem, x, callback) {
+			if (elem.scrollTo) {
 				elem.scrollTo({ left: x, behavior: "smooth" });
 			}
 			else {
 				elem.scrollLeft = x;
 			}
-			var activeSlides = activeItems( elem );
+			var activeSlides = activeItems(elem);
 
-			$( elem ).trigger( pluginName + ".after-goto", {
-			 	activeSlides: activeSlides[ 0 ]
-			 });
-			if( callback ){ 
+			elem.closest('.snapper').dispatchEvent(new CustomEvent(`${pluginName}.after-goto`, { bubbles: true }), {
+				activeSlides: activeSlides[0]
+			});
+			if (hasjQuery) {
+				$(elem.closest('.snapper')).trigger(`${pluginName}.after-goto`);
+			}
+			if (callback) {
 				callback();
 			};
 		}
 
-		var result, innerResult;
+		var innerResult;
 
 		// Loop through snapper elements and enhance/bind events
-		result = this.each(function(){
-			if( innerResult !== undefined ){
+		elements.forEach(function (snap) {
+			if (innerResult !== undefined) {
 				return;
 			}
 
-			var self = this;
-			var $self = $( self );
-			var addNextPrev = $self.is( "[data-" + pluginName + "-nextprev]" );
+			var self = snap;
+			var addNextPrev = snap.hasAttribute(`data-${pluginName}-nextprev`);
 			var autoTimeout;
-			var $slider = $( "." + pluginName + "_pane", self );
+			var slider = snap.querySelector(`.${pluginName}_pane`)
 			// give the pane a tabindex for arrow key handling
-			$slider.attr("tabindex", "0");
-			var $itemsContain = $slider.find( "." + pluginName + "_items" );
-			// make sure items are ID'd. This is critical for arrow nav and sorting.
-			idItems( $itemsContain );
-			var $items = $itemsContain.children();
-			$items.addClass( pluginName + "_item" );
-			var numItems = $items.length;						
+			slider.setAttribute("tabindex", "0");
+			var items = slider.querySelector(`.${pluginName}_items`)
 
-			if( typeof optionsOrMethod === "string" ){
-				var args = Array.prototype.slice.call(pluginArgs, 1);
+			for (var item of items.children) {
+				// make sure items are ID'd. This is critical for arrow nav and sorting.
+				if (item.getAttribute("id") === undefined) {
+					item.setAttribute("id", new Date().getTime());
+				}
+				item.classList.add(`${pluginName}_item`)
+			}
+
+			if (typeof optionsOrMethod === "string") {
+				var args = usesjQuery ? pluginArgs : Array.prototype.slice.call(pluginArgs, 1);
 				var index;
 
-				switch(optionsOrMethod) {
-				case "goto":
-					index = args[0] % numItems;
+				switch (optionsOrMethod) {
+					case "goto":
+						index = args[1] % items.children.length;
 
-					var offset = $itemsContain.children().eq(index)[0].offsetLeft;
-					goto( $slider[ 0 ], offset, function(){
-						// invoke the callback if it was supplied
-						if( typeof args[1] === "function" ){
-							args[1]();
-						}
-					});
-					break;
-				case "getIndex":
-					innerResult = activeItems($slider).index();
-					break;
+						var offset = items.children[index].offsetLeft;
+						goto(slider, offset, function () {
+							// invoke the callback if it was supplied
+							if (typeof args[1] === "function") {
+								args[1]();
+							}
+						});
+						break;
+					case "getIndex":
+						var currentItem = activeItems(slider)[0];
+						innerResult = Array.from(currentItem.parentElement.children).findIndex(child => child === currentItem)
+						break;
 				}
 				return;
 			}
 
 			// avoid double enhance activities
-			if( $self.attr("data-" + pluginName + "-enhanced") ) {
+			if (snap.getAttribute(`data-${pluginName}-enhanced`)) {
 				return;
 			}
 
-			observeItems($slider[ 0 ]);
+			observeItems(slider);
 
 			// if the nextprev option is set, add the nextprev nav
-			if( addNextPrev ){
-				var	$nextprev = $( '<ul class="snapper_nextprev"><li class="snapper_nextprev_item"><a href="#prev" class="snapper_nextprev_prev">Prev</a></li><li class="snapper_nextprev_item"><a href="#next" class="snapper_nextprev_next">Next</a></li></ul>' );
-				var $nextprevContain = $( ".snapper_nextprev_contain", self );
-				if( !$nextprevContain.length ){
-					$nextprevContain = $( self );
+			if (addNextPrev) {
+				var nextprev = document.createElement('ul');
+				nextprev.classList.add('snapper_nextprev');
+				nextprev.innerHTML = '<li class="snapper_nextprev_item"><a href="#prev" class="snapper_nextprev_prev">Prev</a></li><li class="snapper_nextprev_item"><a href="#next" class="snapper_nextprev_next">Next</a></li>';
+				var nextprevContain = self.querySelector(".snapper_nextprev_contain");
+				if (!nextprevContain) {
+					nextprevContain = self;
 				}
-				$nextprev.appendTo( $nextprevContain );
+				nextprevContain.appendChild(nextprev);
 			}
 
 			// This click binding will allow linking to slides from thumbnails without causing the page to scroll to the carousel container
 			// this also supports click handling for generated next/prev links
-			$( "a", this ).bind( "click", function( e ){
-				clearTimeout(autoTimeout);
-				var slideID = $( this ).attr( "href" );
+			snap.querySelectorAll("a").forEach(el => {
+				el.addEventListener("click", function (e) {
+					clearTimeout(autoTimeout);
+					var slideID = this.getAttribute("href");
 
-				if( $( this ).is( ".snapper_nextprev_next" ) ){
-					e.preventDefault();
-					return arrowNavigate( true );
-				}
-				else if( $( this ).is( ".snapper_nextprev_prev" ) ){
-					e.preventDefault();
-					return arrowNavigate( false );
-				}
-				// internal links to slides
-				else if( slideID.indexOf( "#" ) === 0 && slideID.length > 1 ){
-					e.preventDefault();
-					gotoSlide( slideID );
-				}
+					if (this.classList.contains("snapper_nextprev_next")) {
+						e.preventDefault();
+						return arrowNavigate(true);
+					}
+					else if (this.classList.contains("snapper_nextprev_prev")) {
+						e.preventDefault();
+						return arrowNavigate(false);
+					}
+					// internal links to slides
+					else if (slideID.indexOf("#") === 0 && slideID.length > 1) {
+						e.preventDefault();
+						gotoSlide(slideID);
+					}
+				});
 			});
 
 			// arrow key bindings for next/prev
-			$( this )
-				.bind( "keydown", function( e ){
-					if( e.keyCode === 37 || e.keyCode === 38 ){
-						clearTimeout(autoTimeout);
-						e.preventDefault();
-						e.stopImmediatePropagation();
-						arrowNavigate( false );
-					}
-					if( e.keyCode === 39 || e.keyCode === 40 ){
-						clearTimeout(autoTimeout);
-						e.preventDefault();
-						e.stopImmediatePropagation();
-						arrowNavigate( true );
-					}
-				} );
+			snap.addEventListener("keydown", function (e) {
+				if (e.keyCode === 37 || e.keyCode === 38) {
+					clearTimeout(autoTimeout);
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					arrowNavigate(false);
+				}
+				if (e.keyCode === 39 || e.keyCode === 40) {
+					clearTimeout(autoTimeout);
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					arrowNavigate(true);
+				}
+			});
 
-			function gotoSlide( href, callback ){
-				var $slide = $( href, self );
-				if( $slide.length ){
-					goto( $slider[ 0 ], $slide[ 0 ].offsetLeft, function(){
-						if( callback ){
+			function gotoSlide(href, callback) {
+				var slide = self.querySelector(href);
+				if (slide) {
+					goto(slider, slide.offsetLeft, function () {
+						if (callback) {
 							callback();
 						}
-					} );
+					});
 				}
 			}
 
 
-			
+
 			var afterResize;
 			var currSlide;
-			function resizeUpdates(){
-				clearTimeout( afterResize );
-				if( !currSlide ){
-					currSlide = activeItems($slider).first();
+			function resizeUpdates() {
+				clearTimeout(afterResize);
+				if (!currSlide) {
+					currSlide = activeItems(slider).length && activeItems(slider)[0];
 				}
-				afterResize = setTimeout( function(){
+				afterResize = setTimeout(function () {
 					// retain snapping on resize 
-					gotoSlide( currSlide.attr("id") );
+					gotoSlide(currSlide.getAttribute("id"));
 					currSlide = null;
 					// resize can reveal or hide slides, so update arrows
-					setArrowState( $self );
-				}, 300 );
+					setArrowState(self);
+				}, 300);
 			}
-			$( w ).bind( "resize", resizeUpdates );
+			window.addEventListener("resize", resizeUpdates);
 
 			// next/prev links or arrows should loop back to the other end when an extreme is reached
-			function arrowNavigate( forward ){
-				if( forward ){
+			function arrowNavigate(forward) {
+				if (forward) {
 					next();
 				}
 				else {
@@ -282,31 +300,38 @@
 			}
 
 			// advance slide one full scrollpane's width forward
-			function next(){
-				var currentActive =  activeItems($slider).first();
-				var next = currentActive.next();
-				if( next.length ){
-					gotoSlide( "#" + next.attr( "id" ), function(){
-						$slider.trigger( pluginName + ".after-next" );
-					} );
+			function next() {
+				var currentActive = activeItems(slider).length && activeItems(slider)[0];
+				var next = currentActive.nextElementSibling;
+				if (next) {
+					gotoSlide(`#${next.getAttribute("id")}`, function () {
+						snap.dispatchEvent(new CustomEvent(`${pluginName}.after-next`, { bubbles: true }));
+						if (hasjQuery) {
+							$(snap).trigger(`${pluginName}.after-next`);
+						}
+					});
 				}
 			}
 
 			// advance slide one full scrollpane's width backwards
-			function prev(){
-				var currentActive =  activeItems($slider).first();
-				var prev = currentActive.prev();
-				if( prev.length ){
-					gotoSlide( "#" + prev.attr( "id" ), function(){
-						$slider.trigger( pluginName + ".after-prev" );
-					} );
+			function prev() {
+				var currentActive = activeItems(slider).length && activeItems(slider)[0];
+				var prev = currentActive.previousElementSibling;
+				if (prev) {
+					gotoSlide(`#${prev.getAttribute("id")}`, function () {
+						snap.dispatchEvent(new CustomEvent(`${pluginName}.after-prev`, { bubbles: true }));
+						if (hasjQuery) {
+							$(snap).trigger(`${pluginName}.after-prev`);
+						}
+					});
 				}
 			}
 
 			function getAutoplayInterval() {
-				var activeSlide = activeItems($slider).last();
-				var autoTiming = activeSlide.attr( "data-snapper-autoplay" ) || $self.attr( "data-snapper-autoplay" );
-				if( autoTiming ) {
+				var currentActive = activeItems(slider)
+				var activeSlide = currentActive.length && currentActive[currentActive.length - 1];
+				var autoTiming = activeSlide && activeSlide.getAttribute("data-snapper-autoplay") || self.getAttribute("data-snapper-autoplay");
+				if (autoTiming) {
 					autoTiming = parseInt(autoTiming, 10) || 5000;
 				}
 				return autoTiming;
@@ -314,14 +339,14 @@
 
 			// if the `data-autoplay` attribute is assigned a natural number value
 			// use it to make the slides cycle until there is a user interaction
-			function autoplay( autoTiming ) {
-				if( autoTiming ){
+			function autoplay(autoTiming) {
+				if (autoTiming) {
 					// autoTimeout is cleared in each user interaction binding
-					autoTimeout = setTimeout(function(){
+					autoTimeout = setTimeout(function () {
 						var timeout = getAutoplayInterval();
-						if( timeout ) {
+						if (timeout) {
 							arrowNavigate(true);
-							autoplay( timeout );
+							autoplay(timeout);
 						}
 					}, autoTiming);
 				}
@@ -329,27 +354,32 @@
 
 			// if a touch event is fired on the snapper we know the user is trying to
 			// interact with it and we should disable the auto play
-			$slider.bind("pointerdown click mouseenter focus", function(){
-				clearTimeout(autoTimeout);
+			["pointerdown", "click", "mouseenter", "focus"].forEach(eventType => {
+				slider.addEventListener(eventType, function () {
+					clearTimeout(autoTimeout);
+				});
 			});
 
 			var scrolling;
-			$slider.bind("scroll", function(){
+			slider.addEventListener("scroll", function () {
 				window.clearTimeout(scrolling);
-				scrolling = setTimeout(function(){
-					updateSort( $slider[0] );
-					setArrowState( $self );
-				},66);
+				scrolling = setTimeout(function () {
+					updateSort(slider);
+					setArrowState(self);
+				}, 66);
 			});
 
-			updateSort( $slider[0] );
-			
-			setArrowState( $self );
+			updateSort(slider);
 
-			autoplay( getAutoplayInterval() );
-			$self.attr("data-" + pluginName + "-enhanced", true);
+			setArrowState(self);
+
+			autoplay(getAutoplayInterval());
+			self.setAttribute(`data-${pluginName}-enhanced`, true);
 		});
 
-		return (innerResult !== undefined ? innerResult : result);
+
+		return innerResult !== undefined
+			? innerResult
+			: (usesjQuery ? this : elements);
 	};
-}( this, jQuery ));
+}());

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,11 +3,208 @@
 */
 
 window.onload = function(){
-	/* TESTS HERE */
+
+	/* vanilla.js API */
+
+	test( 'API Properties: snapper is a function', function() {
+		ok( typeof( snapper ) === "function" );
+	});
+
+
+	asyncTest( 'Enhancement steps', function() {
+		$(function(){
+			snapper(document.querySelectorAll( ".snapper" ));
+			start();
+			ok($(".snapper_nextprev").length, "next prev generated");
+			ok($(".snapper_nextprev a").length === 2, "2 next prev links");
+		});
+	});
 
 	
+	asyncTest( 'Snapping occurs after scrolling to a spot that is not a snap point', function() {
+		expect(1);
+		snapper(document.querySelectorAll( ".snapper" ));
+		$(".snapper_pane")[0].scrollLeft = 0;
+		$(".snapper_pane")[0].scrollLeft = 35;
+		setTimeout(function(){
+			ok( $(".snapper_pane")[0].scrollLeft === 0 );
+			start();
+		},1000);
+	});
+	
+	
+	asyncTest( 'thumbnail clicks cause pane to scroll', function() {
+		snapper(document.querySelectorAll( ".snapper" ));
+		expect(1);
+		$(".snapper_pane")[0].scrollLeft = 0;
+		document.querySelector('.snapper_nav a:last-child').dispatchEvent(new Event('click'))
+		setTimeout(function(){
+			ok( $(".snapper_pane")[0].scrollLeft !== 0, "scroll changed" );
+		 	start();
+		},1000);
+	});
 
-	//snapper tests
+
+	asyncTest( 'disabled arrow classes are present at extremes', function() {
+		snapper(document.querySelectorAll( ".snapper" ));
+		expect(4);
+		
+		setTimeout(function(){
+			ok( $(".snapper_nextprev_prev.snapper_nextprev-disabled").length === 0, "prev link is not disabled ");
+			ok( $(".snapper_nextprev_next.snapper_nextprev-disabled").length === 1, "next link is disabled ");
+		 	start();
+		 },2000);
+
+		 ok( $(".snapper_nextprev_prev.snapper_nextprev-disabled").length === 1, "prev link is disabled ");
+		 ok( $(".snapper_nextprev_next.snapper_nextprev-disabled").length === 0, "next link is not disabled ");
+ 
+		 $(".snapper_pane")[0].scrollTo(5000,0);
+	});
+
+
+	asyncTest( 'Arrows navigate', function() {
+		snapper(document.querySelectorAll( ".snapper" ));
+		expect(1);
+		$(".snapper_pane")[0].scrollLeft = 0;
+		
+		setTimeout(function(){
+		    ok( $(".snapper_pane")[0].scrollLeft !== 0, "scroll changed" );
+		 	start();
+		 }, 2000);
+		 setTimeout(() => {
+			document.querySelector(".snapper_nextprev_next").click();
+		 }, 1000);
+	});
+
+
+	asyncTest( 'Arrows navigate back', function() {
+		snapper(document.querySelectorAll( ".snapper" ));
+		expect(2);
+		$(".snapper_pane")[0].scrollLeft = 0;
+
+		setTimeout(function(){
+			ok( $(".snapper_pane")[0].scrollLeft === 0, "scroll changed" );
+			start();
+		}, 4000);
+
+		 setTimeout(function(){
+			ok( $(".snapper_pane")[0].scrollLeft !== 0, "scroll changed" );
+			document.querySelector(".snapper_nextprev_prev").click();
+		 }, 2000);
+
+		 setTimeout(function(){
+			document.querySelector(".snapper_nextprev_next").click();
+		 }, 1000);
+	});
+
+
+	asyncTest( 'random # link clicks are ignored', function() {
+		snapper(document.querySelectorAll( ".snapper" ));
+		expect(1);
+		document.getElementById("testlink").click();
+		ok( true );
+		start();
+	});
+
+	
+	asyncTest( 'get index returns correct index after goto', function(){
+		var snapperInstance = snapper(document.querySelectorAll( ".snapper" ));
+		expect(1);
+		
+	
+		setTimeout(function(){
+			equal(snapper(snapperInstance, "getIndex"), 1);
+			start();
+		}, 2000);
+
+		snapper(snapperInstance, "goto", 1);
+	});
+
+
+	asyncTest( 'autoplay advances a few times once started', function(){
+		expect(2);
+		var eventCounter = 0;
+		var checkBinding;
+		var snapperElem = document.querySelectorAll( ".snapper" )
+
+		snapperElem[0].setAttribute( "data-snapper-autoplay", "500" );
+
+		snapperElem[0].addEventListener("snapper.after-goto", checkBinding = function(){
+			ok(true, "after-goto called");
+
+			if(++eventCounter === 2){
+				snapperElem[0].removeAttribute( "data-snapper-autoplay" );
+				snapperElem[0].removeEventListener("snapper.after-goto", checkBinding);
+				start();
+			} 
+		});
+
+		snapper(snapperElem);
+	});
+
+
+	asyncTest( 'looping goes endlessly forward', function(){
+		expect(5);
+		var eventCounter = 0;
+		var checkBinding;
+		var snapperElem = document.querySelectorAll( ".snapper" )
+
+		snapperElem[0].setAttribute( "data-snapper-loop", true );
+
+		snapperElem[0].addEventListener("snapper.after-next", checkBinding = function(){
+			ok(true, "after-next called");
+			
+			if(++eventCounter === 5){
+				snapperElem[0].removeAttribute( "data-snapper-loop" );
+				snapperElem[0].removeEventListener("snapper.after-next", checkBinding);
+				start();
+			}
+			else{
+				setTimeout(() => {
+					document.querySelector(".snapper_nextprev_next").click();
+				}, 1000);
+			} 
+		});
+
+		snapper(snapperElem);
+		setTimeout(() => {
+			document.querySelector(".snapper_nextprev_next").click();
+		 }, 100);
+	});
+
+
+	asyncTest( 'looping goes endlessly in reverse', function(){
+		expect(5);
+		var eventCounter = 0;
+		var checkBinding;
+		var snapperElem = document.querySelectorAll(".snapper");
+
+		snapperElem[0].setAttribute( "data-snapper-loop", true );
+
+		snapperElem[0].addEventListener("snapper.after-prev", checkBinding = function(){
+			ok(true, "after-prev called");
+
+			if(++eventCounter === 5){
+				snapperElem[0].removeAttribute( "data-snapper-loop" );
+				snapperElem[0].removeEventListener("snapper.after-prev", checkBinding);
+				start();
+			}
+			else{
+				setTimeout(() => {
+					document.querySelector(".snapper_nextprev_prev").click();
+				}, 1000)
+			} 
+		});
+
+		snapper(snapperElem);
+		setTimeout(() => {
+			document.querySelector(".snapper_nextprev_prev").click();
+		 }, 100);
+	});
+
+
+	/* jQuery API */
+	
 	test( 'API Properties: $.fn.snapper is a function', function() {
 		ok( typeof( $.fn.snapper ) === "function" );
 	});
@@ -19,8 +216,6 @@ window.onload = function(){
 			ok($(".snapper_nextprev").length, "next prev generated");
 			ok($(".snapper_nextprev a").length === 2, "2 next prev links");
 		});
-		
-		
 	});
 
 	
@@ -41,7 +236,7 @@ window.onload = function(){
 		$(".snapper").snapper();
 		expect(1);
 		$(".snapper_pane")[0].scrollLeft = 0;
-		 $(".snapper_nav a").last().trigger( "click" );
+		 $(".snapper_nav a").last()[0].click();
 		 setTimeout(function(){
 			 ok( $(".snapper_pane")[0].scrollLeft !== 0, "scroll changed" );
 		 	 start();
@@ -52,7 +247,6 @@ window.onload = function(){
 	asyncTest( 'disabled arrow classes are present at extremes', function() {
 		$(".snapper").snapper();
 		expect(4);
-		
 		
 		setTimeout(function(){
 			ok( $(".snapper_nextprev_prev.snapper_nextprev-disabled").length === 0, "prev link is not disabled ");
@@ -77,7 +271,7 @@ window.onload = function(){
 		 	 start();
 		 },2000);
 		 setTimeout(() => {
-			$(".snapper_nextprev_next").click();
+			$(".snapper_nextprev_next")[0].click();
 		 }, 1000);
 	});
 
@@ -94,19 +288,13 @@ window.onload = function(){
 
 		 setTimeout(function(){
 			 ok( $(".snapper_pane")[0].scrollLeft !== 0, "scroll changed" );
-			 $(".snapper_nextprev_prev").click();
+			 $(".snapper_nextprev_prev")[0].click();
 		 },2000);
 
 		 setTimeout(function(){
-			$(".snapper_nextprev_next").click();
+			$(".snapper_nextprev_next")[0].click();
 		 }, 1000);
 	});
-
-
-
-
-
-
 
 
 	asyncTest( 'random # link clicks are ignored', function() {
@@ -117,12 +305,10 @@ window.onload = function(){
 		start();
 	});
 
-	
 
 	asyncTest( 'get index returns correct index after goto', function(){
 		var $snapper = $(".snapper").snapper();
 		expect(1);
-		
 	
 		setTimeout(function(){
 			equal($snapper.snapper("getIndex"), 1);
@@ -132,12 +318,12 @@ window.onload = function(){
 		$snapper.snapper("goto", 1);
 	});
 
+
 	asyncTest( 'autoplay advances a few times once started', function(){
 		expect(2);
 		var eventCounter = 0;
 		var checkBinding;
 		var $snapperElem = $(".snapper");
-		var $snapper;
 
 		$snapperElem.attr( "data-snapper-autoplay", "500" );
 
@@ -154,32 +340,34 @@ window.onload = function(){
 		$snapperElem.snapper();
 	});
 
+
 	asyncTest( 'looping goes endlessly forward', function(){
 		expect(5);
 		var eventCounter = 0;
 		var checkBinding;
 		var $snapperElem = $(".snapper");
-		var $snapper;
 
 		$snapperElem.attr( "data-snapper-loop", "500" );
 
-		$snapperElem.bind("snapper.after-next", checkBinding = function(){
+		$snapperElem.on("snapper.after-next", checkBinding = function(){
 			ok(true, "after-next called");
 
 			if(++eventCounter === 5){
 				$snapperElem.removeAttr( "data-snapper-loop" );
-				$(document).unbind("snapper.after-goto", checkBinding);
+				$(document).off("snapper.after-next", checkBinding);
 				start();
 			}
 			else{
-				$(".snapper_nextprev_next").click();
+				setTimeout(() => {
+					$(".snapper_nextprev_next")[0].click();
+				}, 1000)
 			} 
 		});
 
 		$snapperElem.snapper();
 		setTimeout(() => {
-			$(".snapper_nextprev_next").click();
-		 }, 500);
+			$(".snapper_nextprev_next")[0].click();
+		 }, 100);
 	});
 
 
@@ -188,27 +376,28 @@ window.onload = function(){
 		var eventCounter = 0;
 		var checkBinding;
 		var $snapperElem = $(".snapper");
-		var $snapper;
 
 		$snapperElem.attr( "data-snapper-loop", "500" );
 
-		$snapperElem.bind("snapper.after-prev", checkBinding = function(){
+		$snapperElem.on("snapper.after-prev", checkBinding = function(){
 			ok(true, "after-prev called");
 
 			if(++eventCounter === 5){
 				$snapperElem.removeAttr( "data-snapper-loop" );
-				$(document).unbind("snapper.after-goto", checkBinding);
+				$(document).off("snapper.after-prev", checkBinding);
 				start();
 			}
 			else{
-				$(".snapper_nextprev_prev").click();
-			} 
+				setTimeout(() => {
+					$(".snapper_nextprev_prev")[0].click();
+				}, 1000);
+			}
 		});
 
 		$snapperElem.snapper();
 		setTimeout(() => {
-			$(".snapper_nextprev_prev").click();
-		 }, 500);
+			$(".snapper_nextprev_prev")[0].click();
+		 }, 100);
 	});
 
 };


### PR DESCRIPTION
Refactoring of the code to remove jQuery as a dependency and introduction of a plain JavaScript API

- Add `snapper` function to window which takes Elements as first parameter
- Add documentation of the available events and methods for JS and jQuery API